### PR TITLE
Remove updates from showing in the WordPress admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
     "class": "HM\\Platform\\CMS\\Composer\\Plugin"
   },
   "autoload": {
-    "classmap": [ "inc/" ]
+    "classmap": [ "inc/" ],
+    "files": [
+      "inc/remove_updates/namespace.php",
+      "load.php"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
   "autoload": {
     "classmap": [ "inc/" ],
     "files": [
-      "inc/remove_updates/namespace.php",
       "load.php"
     ]
   }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace HM\Platform\CMS;
+
+function bootstrap() {
+	require_once __DIR__ . '/remove_updates/namespace.php';
+
+	Remove_Updates\bootstrap();
+}

--- a/inc/remove_updates/namespace.php
+++ b/inc/remove_updates/namespace.php
@@ -2,6 +2,11 @@
 
 namespace HM\Platform\CMS\Remove_Updates;
 
+function bootstrap() {
+	add_action( 'admin_init', 'HM\\Platform\\CMS\\Remove_Updates\\remove_update_nag' );
+	add_action( 'plugins_loaded', 'HM\\Platform\\CMS\\Remove_Updates\\remove_update_check_cron' );
+}
+
 /**
  * Remove the update nag messages from the admin header.
  *

--- a/inc/remove_updates/namespace.php
+++ b/inc/remove_updates/namespace.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace HM\Platform\CMS\Remove_Updates;
+
+/**
+ * Remove the update nag messages from the admin header.
+ *
+ * Because we provide WordPress updates via the Platform central version, we don't want
+ * to be nagging users about available updates.
+ */
+function remove_update_nag() {
+	remove_filter( 'admin_notices', 'update_nag', 3 );
+	remove_filter( 'network_admin_notices', 'update_nag', 3 );
+	remove_filter( 'update_footer', 'core_update_footer' );
+}
+
+/**
+ * Remove the update cron checks.
+ *
+ * We don't want to be wasting energy with checking always for available updates. Those are done out
+ * of band, at the VCS level.
+ */
+function remove_update_check_cron() {
+	remove_action( 'init', 'wp_schedule_update_checks' );
+}

--- a/load.php
+++ b/load.php
@@ -1,0 +1,4 @@
+<?php
+
+add_action( 'admin_init', 'HM\\Platform\\CMS\\Remove_Updates\\remove_update_nag' );
+add_action( 'plugins_loaded', 'HM\\Platform\\CMS\\Remove_Updates\\remove_update_check_cron' );

--- a/load.php
+++ b/load.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace HM\Platform\CMS;
+
 use function HM\Platform\register_module;
 
 require_once __DIR__ . '/inc/namespace.php';

--- a/load.php
+++ b/load.php
@@ -1,4 +1,18 @@
 <?php
 
-add_action( 'admin_init', 'HM\\Platform\\CMS\\Remove_Updates\\remove_update_nag' );
-add_action( 'plugins_loaded', 'HM\\Platform\\CMS\\Remove_Updates\\remove_update_check_cron' );
+namespace HM\Platform\CMS;
+use function HM\Platform\register_module;
+
+require_once __DIR__ . '/inc/namespace.php';
+
+// Register core module.
+add_action( 'hm-platform.modules.init', function () {
+	$default_settings = [
+		'enabled'    => true,
+		'branding'   => true,
+		'login-logo' => null,
+	];
+	register_module( 'cms', __DIR__, 'CMS', $default_settings, __NAMESPACE__ . '\\bootstrap' );
+} );
+
+


### PR DESCRIPTION
This removes the update nags and cron checks for themes, plugins and core.