### PR TITLE
Use __DIR__ to ensure WP CLI gets correct path

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'WP_CONTENT_DIR' ) ) {
-	define( 'WP_CONTENT_DIR', $_SERVER['DOCUMENT_ROOT'] . '/content' );
+	define( 'WP_CONTENT_DIR', __DIR__ . '/content' );
 }
 
 if ( ! defined( 'WP_CONTENT_URL' ) ) {


### PR DESCRIPTION
When using WP CLI I noticed that the content directory was set to `/wordpress/content`. Using `__DIR__` means it's correct for both the CLI and web server.