### PR TITLE
Add default splash page

### DIFF
--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -95,7 +95,10 @@ function detect_missing_default_theme() {
 	$message = sprintf(
 		'<h1>%s</h1><p>%s</p><p><small>%s</small></p>',
 		$title,
-		__( 'HM Platform is installed and ready to go. Activate a theme to get started.', 'hm-platform' ),
+		sprintf(
+			__( 'HM Platform is installed and ready to go. <a href="%s">Activate a theme to get started</a>.', 'hm-platform' ),
+			admin_url( 'themes.php' )
+		),
 		__( 'You‘re seeing this page because debug mode is enabled, and the default theme directory is missing.', 'hm-platform' )
 	);
 

--- a/inc/branding/namespace.php
+++ b/inc/branding/namespace.php
@@ -75,7 +75,7 @@ function override_default_color_scheme( $value ) : string {
  */
 function detect_missing_default_theme() {
 	$env = get_environment_type();
-	if ( $env !== 'development' && $env !== 'local' ) {
+	if ( ! in_array( $env, [ 'development', 'local' ], true ) ) {
 		return;
 	}
 


### PR DESCRIPTION
This adds a default splash page to improve the new user experience. This splash page is only triggered when:
* The theme is set to the default
* The theme is missing
* You're on development or local environments

<img width="803" alt="Screenshot 2019-03-25 16 52 50" src="https://user-images.githubusercontent.com/21655/54938577-8164f080-4f1e-11e9-860f-8306af77d177.png">

This is modelled off the default Symfony splash page:
![Screenshot_2019-03-25 Welcome ](https://user-images.githubusercontent.com/21655/54938596-8aee5880-4f1e-11e9-92e5-50ddd6f5458a.png)

We should further theme this with branding colours, but do this via the `wp_die()` handler rather than here.