### PR TITLE
Add check for add_action

### DIFF
--- a/load.php
+++ b/load.php
@@ -8,6 +8,11 @@ require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/remove_updates/namespace.php';
 require_once __DIR__ . '/inc/branding/namespace.php';
 
+// Don't self-initialize if this is not a Platform execution.
+if ( ! function_exists( 'add_action' ) ) {
+	return;
+}
+
 // Register core module.
 add_action( 'hm-platform.modules.init', function () {
 	$default_settings = [


### PR DESCRIPTION
Per https://github.com/humanmade/platform-dev/issues/323, we are screwing up any inclusion of autoload.php outside of the wp-config.php. We're discussing a better long term solution in https://github.com/humanmade/platform-dev/pull/325, but this is intended to get things functioning.