### PR TITLE
Add the WP installer to this package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
   "require": {
     "php": ">=7.1",
     "stuttter/wp-user-signups": "3.1.0",
+    "johnpbloch/wordpress": "5.2.0",
     "humanmade/cms-installer": "0.1.0"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=7.1",
     "stuttter/wp-user-signups": "3.1.0",
-    "johnpbloch/wordpress": "~5.2.0",
+    "johnpbloch/wordpress": "5.2.0",
     "humanmade/cms-installer": "0.1.0"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": ">=7.1",
     "stuttter/wp-user-signups": "3.1.0",
-    "johnpbloch/wordpress": "5.2.0",
+    "johnpbloch/wordpress": "~5.2.0",
     "humanmade/cms-installer": "0.1.0"
   },
   "extra": {


### PR DESCRIPTION
Will mean we have less updates to do on cms-installer and we can control the WP version with less effort.

Updating to 5.2 at the same time. Question though, should we make this `~5.2.0` to reduce WP upgrading friction?

Related to https://github.com/humanmade/platform-cms-installer/pull/5